### PR TITLE
[Feat] BloomFilter 기반 중복 공고 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Redisson 4.3.0
+    implementation 'org.redisson:redisson-spring-boot-starter:4.3.0'
+
     // Spring AI
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 

--- a/src/main/java/navik/crawler/constants/JobKoreaConstant.java
+++ b/src/main/java/navik/crawler/constants/JobKoreaConstant.java
@@ -4,4 +4,5 @@ public class JobKoreaConstant {
 	public static final String BASE_URL = "https://www.jobkorea.co.kr";
 	public static final String RECRUITMENT_LIST_URL = "https://www.jobkorea.co.kr/recruit/joblist?menucode=duty";
 	public static final String RECRUITMENT_DETAIL_URL_PATTERN = "https://www.jobkorea.co.kr/Recruit/GI_Read/(\\d+)";
+	public static final String BLOOM_FILTER_NAME = "bf:jobkorea:post-id";
 }

--- a/src/main/java/navik/crawler/constants/JobKoreaConstant.java
+++ b/src/main/java/navik/crawler/constants/JobKoreaConstant.java
@@ -5,4 +5,6 @@ public class JobKoreaConstant {
 	public static final String RECRUITMENT_LIST_URL = "https://www.jobkorea.co.kr/recruit/joblist?menucode=duty";
 	public static final String RECRUITMENT_DETAIL_URL_PATTERN = "https://www.jobkorea.co.kr/Recruit/GI_Read/(\\d+)";
 	public static final String BLOOM_FILTER_NAME = "bf:jobkorea:post-id";
+	public static final long BLOOM_FILTER_INSERTION_SIZE = 1000;
+	public static final double BLOOM_FILTER_FPP = 0.05;
 }

--- a/src/main/java/navik/crawler/service/CrawlerService.java
+++ b/src/main/java/navik/crawler/service/CrawlerService.java
@@ -25,6 +25,8 @@ import navik.crawler.factory.WebDriverFactory;
 import navik.crawler.util.CrawlerDataExtractor;
 import navik.crawler.util.CrawlerSearchHelper;
 import navik.crawler.util.CrawlerValidator;
+import navik.redis.bloomFilter.factory.RedisBloomFilterFactory;
+import navik.redis.bloomFilter.wrapper.RedisBloomFilter;
 import navik.redis.client.RedisStreamProducer;
 import navik.redis.congestion.RedisCongestionManager;
 
@@ -41,6 +43,7 @@ public class CrawlerService {
 	private final EmbeddingClient embeddingClient;
 	private final RedisStreamProducer redisStreamProducer;
 	private final RedisCongestionManager redisCongestionManager;
+	private final RedisBloomFilterFactory redisBloomFilterFactory;
 
 	@Value("${spring.data.redis.stream.crawl.key}")
 	private String recruitmentStreamKey;
@@ -148,25 +151,33 @@ public class CrawlerService {
 	 */
 	public void processETL(WebDriverWait wait) {
 
-		// 1. 채용 공고 상세 페이지 url 유효성 검사
+		// 1. 채용 공고 중복 처리 검사
+		RedisBloomFilter bloomFilter = redisBloomFilterFactory.getBloomFilter(JobKoreaConstant.BLOOM_FILTER_NAME);
+		String postId = crawlerDataExtractor.extractPostId(wait);
+		if (bloomFilter.mightContain(postId)) {
+			log.info("이미 추출된 채용 공고 postId: {}", postId);
+			return;
+		}
+
+		// 2. 채용 공고 상세 페이지 url 유효성 검사
 		String link = crawlerDataExtractor.extractCurrentUrl(wait);
 		if (!crawlerValidator.isValidDetailUrl(link)) {
 			log.info("유효하지 않은 채용 공고 링크: {}", link);
 			return;
 		}
 
-		// 2. 제목 유효성 검사
+		// 3. 제목 유효성 검사
 		String title = crawlerDataExtractor.extractTitle(wait);
 		if (crawlerValidator.isSkipTitle(title)) {
 			log.info("유효하지 않은 채용 공고 제목: {}", title);
 			return;
 		}
 
-		// 3. 나머지 데이터 추출 및 DTO 작성
+		// 4. 나머지 데이터 추출 및 DTO 작성
 		CrawledRecruitment crawledRecruitment = CrawledRecruitment.builder()
 			.link(link)
 			.title(title)
-			.postId(crawlerDataExtractor.extractPostId(wait))
+			.postId(postId)
 			.companyName(crawlerDataExtractor.extractCompanyName(wait))
 			.companyLogo(crawlerDataExtractor.extractCompanyLogo(wait))
 			.companyInfo(crawlerDataExtractor.extractCompanyInfo(wait))
@@ -176,12 +187,12 @@ public class CrawlerService {
 			.recruitmentDetail(crawlerDataExtractor.extractRecruitmentDetail(wait))
 			.build();
 
-		// 4. LLM 호출
+		// 5. LLM 호출
 		String html = crawledRecruitment.toHtmlString();
 		LLMResponseDTO.Recruitment llmResult = llmClient.getRecruitment(html);
 		log.info("[LLM 채용 공고 결과] {}", llmResult);
 
-		// 5. KPI 임베딩
+		// 6. KPI 임베딩
 		List<Recruitment.Position> positions = llmResult.getPositions().stream()
 			.map(llmPosition -> {
 				List<Recruitment.Position.KPI> kpis = llmPosition.getKpis().stream()
@@ -205,7 +216,7 @@ public class CrawlerService {
 					.build();
 			}).toList();
 
-		// 6. DTO 생성
+		// 7. DTO 생성
 		Recruitment recruitment = Recruitment.builder()
 			.link(llmResult.getLink())
 			.title(llmResult.getTitle())
@@ -220,7 +231,7 @@ public class CrawlerService {
 			.summary(llmResult.getSummary())
 			.build();
 
-		// 7. 혼잡 확인 커맨드 전송 및 exponential back-off로 부하 감소
+		// 8. 혼잡 확인 커맨드 전송 및 exponential back-off로 부하 감소
 		long delay = 1000L; // first 1s
 		final long maxDelay = 30000L; // max 30s
 		while (redisCongestionManager.isCongested(recruitmentStreamKey, recruitmentGroupName)) {
@@ -235,7 +246,10 @@ public class CrawlerService {
 			delay = Math.min(delay * 2, maxDelay);
 		}
 
-		// 8. 발행
+		// 9. 발행
 		redisStreamProducer.produceRecruitment(recruitmentStreamKey, recruitment);
+
+		// 10. Bloom filter 기록
+		bloomFilter.put(postId);
 	}
 }

--- a/src/main/java/navik/redis/bloomFilter/config/RedisBloomFilterConfig.java
+++ b/src/main/java/navik/redis/bloomFilter/config/RedisBloomFilterConfig.java
@@ -1,0 +1,26 @@
+package navik.redis.bloomFilter.config;
+
+import java.util.Collections;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import navik.crawler.constants.JobKoreaConstant;
+import navik.redis.bloomFilter.factory.RedisBloomFilterFactory;
+
+@Configuration
+public class RedisBloomFilterConfig {
+
+	@Bean
+	public ApplicationRunner initBloomFilters(RedisBloomFilterFactory factory) {
+		return args -> {
+			factory.createBloomFilter(
+				JobKoreaConstant.BLOOM_FILTER_NAME,
+				JobKoreaConstant.BLOOM_FILTER_INSERTION_SIZE,
+				Collections.emptyList(),
+				JobKoreaConstant.BLOOM_FILTER_FPP
+			);
+		};
+	}
+}

--- a/src/main/java/navik/redis/bloomFilter/factory/RedisBloomFilterFactory.java
+++ b/src/main/java/navik/redis/bloomFilter/factory/RedisBloomFilterFactory.java
@@ -1,0 +1,52 @@
+package navik.redis.bloomFilter.factory;
+
+import java.util.Collection;
+
+import org.redisson.api.RBloomFilter;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import navik.redis.bloomFilter.wrapper.RedisBloomFilter;
+
+@Component
+@RequiredArgsConstructor
+public class RedisBloomFilterFactory {
+
+	private final RedissonClient redissonClient;
+
+	/**
+	 * 필터 이름 기반 단순 조회용
+	 */
+	public RedisBloomFilter getBloomFilter(String filterName) {
+		RBloomFilter<String> filter = redissonClient.getBloomFilter(filterName);
+		return new RedisBloomFilter(filter);
+	}
+
+	/**
+	 * 필터 생성 및 초기 데이터 적재용
+	 */
+	public RedisBloomFilter createBloomFilter(
+		String filterName,
+		long insertionSize,
+		Collection<String> values,
+		double fpp
+	) {
+
+		// 1. 필터 get
+		RedisBloomFilter redisBloomFilter = getBloomFilter(filterName);
+
+		// 2. 최초 필터인 경우 초기화 (이미 존재하면 초기화되지 않음)
+		redissonClient.getBloomFilter(filterName).tryInit(insertionSize, fpp);
+
+		// 3. 초기 데이터 적재
+		if (values != null && !values.isEmpty()) {
+			for (String v : values) {
+				redisBloomFilter.put(v);
+			}
+		}
+
+		// 4. return
+		return redisBloomFilter;
+	}
+}

--- a/src/main/java/navik/redis/bloomFilter/wrapper/RedisBloomFilter.java
+++ b/src/main/java/navik/redis/bloomFilter/wrapper/RedisBloomFilter.java
@@ -1,0 +1,22 @@
+package navik.redis.bloomFilter.wrapper;
+
+import org.redisson.api.RBloomFilter;
+
+// Wrapper
+public class RedisBloomFilter {
+
+	private final RBloomFilter<String> bloomFilter;
+
+	public RedisBloomFilter(RBloomFilter<String> bloomFilter) {
+		this.bloomFilter = bloomFilter;
+	}
+
+	public void put(String key) {
+		bloomFilter.add(key);
+	}
+
+	public boolean mightContain(String key) {
+		return bloomFilter.contains(key);
+	}
+}
+

--- a/src/main/java/navik/redis/config/RedisConfig.java
+++ b/src/main/java/navik/redis/config/RedisConfig.java
@@ -1,10 +1,13 @@
 package navik.redis.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.spring.data.connection.RedissonConnectionFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -17,11 +20,21 @@ public class RedisConfig {
 	private int port;
 
 	/**
-	 * Redis 연결을 위한 'Connection'을 생성합니다.
+	 * Redisson Client 빈을 생성합니다.
 	 */
 	@Bean
-	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+
+	/**
+	 * Redisson Client 기반으로 RedisConnectionFactory 빈을 생성합니다.
+	 */
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(RedissonClient redissonClient) {
+		return new RedissonConnectionFactory(redissonClient);
 	}
 
 	/**
@@ -29,11 +42,11 @@ public class RedisConfig {
 	 * 해당 구성된 RedisTemplate을 통해서 데이터 통신으로 처리되는 대한 직렬화를 수행합니다.
 	 */
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate() {
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
 		// Redis를 연결합니다.
-		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
 
 		// Key-Value 형태로 직렬화를 수행합니다.
 		redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/src/test/java/navik/crawler/service/CrawlerServiceTest.java
+++ b/src/test/java/navik/crawler/service/CrawlerServiceTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,9 +29,11 @@ import navik.ai.enums.ExperienceType;
 import navik.ai.enums.IndustryType;
 import navik.ai.enums.JobType;
 import navik.ai.enums.MajorType;
+import navik.crawler.constants.JobKoreaConstant;
 import navik.crawler.dto.Recruitment;
 import navik.crawler.util.CrawlerDataExtractor;
 import navik.crawler.util.CrawlerValidator;
+import navik.redis.bloomFilter.factory.RedisBloomFilterFactory;
 import navik.redis.client.RedisStreamProducer;
 import navik.redis.config.RedisTestContainersConfig;
 import navik.redis.congestion.RedisCongestionManager;
@@ -41,6 +45,8 @@ class CrawlerServiceTest extends RedisTestContainersConfig {
 	private CrawlerService crawlerService;
 	@Autowired
 	private RedisTemplate<String, String> redisTemplate;
+	@Autowired
+	private RedisBloomFilterFactory redisBloomFilterFactory;
 
 	@MockitoBean
 	private CrawlerDataExtractor crawlerDataExtractor;
@@ -94,7 +100,6 @@ class CrawlerServiceTest extends RedisTestContainersConfig {
 	void processETL_Success_WhenRedisNotInCongestion() {
 		// given
 		setupDefaultMocks();
-		doReturn(false).when(redisCongestionManager).isCongested(TEST_STREAM_KEY, TEST_GROUP_NAME);
 
 		// when
 		crawlerService.processETL(wait);
@@ -102,6 +107,38 @@ class CrawlerServiceTest extends RedisTestContainersConfig {
 		// then
 		verify(redisCongestionManager, times(1)).isCongested(TEST_STREAM_KEY, TEST_GROUP_NAME);
 		verify(redisStreamProducer, times(1)).produceRecruitment(eq(TEST_STREAM_KEY), any(Recruitment.class));
+	}
+
+	@Test
+	@DisplayName("processETL() - BloomFilter에 의해 이미 처리된 공고(게시글 식별번호: postId)는 처리하지 않는다.")
+	void precessETL_Duplicated_No_Process() {
+		// given
+		setupDefaultMocks();
+		doReturn(false).when(redisCongestionManager).isCongested(anyString(), anyString());
+
+		// postId: 0 ~ 999 까지 이미 추출된 상황
+		String bloomFilterName = JobKoreaConstant.BLOOM_FILTER_NAME;
+		long insertionSize = JobKoreaConstant.BLOOM_FILTER_INSERTION_SIZE;
+		double fpp = JobKoreaConstant.BLOOM_FILTER_FPP;
+		List<String> initValues = IntStream.range(0, (int)insertionSize)
+			.mapToObj(i -> String.valueOf(i))
+			.toList();
+		redisBloomFilterFactory.createBloomFilter(bloomFilterName, insertionSize, initValues, fpp);
+
+		// 동일 postId로 추출 시도
+		AtomicInteger atomicInteger = new AtomicInteger(0);
+		when(crawlerDataExtractor.extractPostId(any())).thenAnswer(invocation ->
+			String.valueOf(atomicInteger.getAndIncrement())
+		);
+
+		// when
+		for (int i = 0; i < 1000; i++) {
+			crawlerService.processETL(wait);
+		}
+
+		// then - 이미 추출된 공고에 대해서는 LLM API 호출, 스트림 발행이 이루어지지 않는다.
+		verify(llmClient, never()).getRecruitment(anyString());
+		verify(redisStreamProducer, never()).produceRecruitment(anyString(), any());
 	}
 
 	private void setupDefaultMocks() {


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #44 

## 🔁 작업 내용

### Redis만 쓰는 제한적인 상황에서 여러 크롤러 간 중복 공고 처리를 어떻게 해결할 수 있을까

- 상황 정리
  - DB 의존성 없이 설계해서 이미 처리된 공고인지 판별 로직이 없었다.
  - 채용 시즌이 아닌 때에는, 새로운 공고가 잘 안 올라와서 이미 처리된 공고를 다시 처리하는 경우 발생
  - 이 때문에 불필요한 LLM 및 OCR API 비용 발생
  - 지금은 크롤러가 한 명인데, 여럿으로 늘면 ...
  - 채용 공고의 url 일련의 숫자를 식별자로 사용하는 상황 
  - 추출할 때마다 어딘가에 기록하여 중복 검사를 하고 불필요한 호출을 줄여보자
  - Redis가 유일한 창구
  - 근데 채용공고는 계속 늘어나는 정보인데, 이걸 Redis나 메모리에 일일이 기록하기는...

- 중복 체크 방법
  - Java Map : 단일 인스턴스에서만 유효, 지금처럼 추출/적재가 분리된 상황에서 크롤러가 늘어난다면 공유가 어려움
  - DB 연결 : DB 안쓰는 제한적인 상황을 가정하였으므로 패스...
  - Bloom Filter : 메모리 효율적인 확률적 자료구조, Redis BitMap 기반으로 구현됨, false positive 단점
  - Cuckoo Filter : Bloom과 유사, 삭제 가능 (Redisson 7.3.0 지원)

- 지금처럼 Redis만 쓰는 상황에서 중복 판별법은 bloom이나 cuckoo가 최선인 거 같다. 
- fpp 때문에 채용공고가 몇 개 스킵된다는 단점은 DB를 쓰지 않는다는 트레이드 오프로써 안고 갈 수 밖에 없을 거 같다.
<br>

- 기존 : 간혹 중복된 공고에 대한 크롤링으로 불필요한 LLM + OCR API 비용 낭비
- 작업 : BloomFilter 기반 중복 공고 처리 및 불필요한 외부 API 호출 비용 절감 

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)